### PR TITLE
Beam packages mix release deterministic

### DIFF
--- a/pkgs/development/beam-modules/build-mix.nix
+++ b/pkgs/development/beam-modules/build-mix.nix
@@ -5,6 +5,7 @@
 , src
 , buildInputs ? [ ]
 , nativeBuildInputs ? [ ]
+, erlangCompilerOptions ? [ ]
 , beamDeps ? [ ]
 , propagatedBuildInputs ? [ ]
 , postPatch ? ""
@@ -31,6 +32,13 @@ let
     MIX_ENV = mixEnv;
     MIX_DEBUG = if enableDebugInfo then 1 else 0;
     HEX_OFFLINE = 1;
+
+    ERL_COMPILER_OPTIONS =
+      let
+        options = [ "deterministic" ] ++ erlangCompilerOptions;
+      in
+      "[${lib.concatStringsSep "," options}]";
+
     LC_ALL = "C.UTF-8";
 
     # add to ERL_LIBS so other modules can find at runtime.
@@ -108,4 +116,3 @@ let
   });
 in
 lib.fix pkg
-


### PR DESCRIPTION
@mattpolzin This is the code I mentioned.

You can also squash [beamPackages.mixRelease: remove erlang references from output](https://github.com/mattpolzin/nixpkgs/pull/1/commits/70cc7e5a73b8097d2f9f7265f72cdcf2e3f20807) to your previous commit.

---

After you updating your branch, you can @ me again. I will post more instructions in <https://github.com/NixOS/nixpkgs/pull/271288>.